### PR TITLE
Actually Stop Execution if Lock Cannot be Acquired

### DIFF
--- a/sync-timeoffs/SyncTimeOffs.js
+++ b/sync-timeoffs/SyncTimeOffs.js
@@ -93,7 +93,7 @@ function syncTimeOffs() {
 
     const scriptLock = LockService.getScriptLock();
     if (!scriptLock.tryLock(5000)) {
-        Logger.log('Failed to acquire lock. Only one instance of this script can run at any given time!');
+        throw new Error('Failed to acquire lock. Only one instance of this script can run at any given time!');
     }
 
     const allowedDomains = (getScriptProperties_().getProperty(ALLOWED_DOMAINS_KEY) || '')


### PR DESCRIPTION
## Reasoning

Towards https://github.com/giantswarm/giantswarm/issues/24049

Only one instance of a script executing `syncTimeOffs()` maybe running at any given time.

However, during testing failure to acquire the ScriptLock didn't cause the script to terminate.

## Fix

Correctly throw an error when `tryLock(...)` returns `false`.