### PR TITLE
Require Keyword Occurrences to be Isolated

### DIFF
--- a/sync-timeoffs/SyncTimeOffs.js
+++ b/sync-timeoffs/SyncTimeOffs.js
@@ -281,7 +281,7 @@ class TimeOffTypeDb {
 
     /** Returns the keyword for the specified TimeOffType name (field timeOffType.attributes.name). */
     static extractKeyword(typeName) {
-        return (typeName || '').attributes.name.split(' ')[0].trim() || undefined;
+        return (typeName || '').split(' ')[0].trim() || undefined;
     }
 
     /** Guess timeOffType from a text (e.g. event summary) by keyword. */


### PR DESCRIPTION
## Reasoning

Keyword occurences shall be isolated.

That is the keyword `out` should match `we are out` and `Out of office` but not `We have an outtage`.

In addition we shall not split by `-` during keyword generation from `TimeOffType.attributes.name`.

## Implementation

1. Splitting by `-` has been removed.
2. Case-insensitive search for keywords in matching constellations in `event.summary` is now implemented using pre-cached regular expressions.