### PR TITLE
Implement skipping approvals and blacklist

### DIFF
--- a/sync-timeoffs/README.md
+++ b/sync-timeoffs/README.md
@@ -28,13 +28,14 @@ Configuring the synchronization is possible using ScriptProperties.
 
 The following configuration properties are available:
 
-| Mandatory | Property Key                             | Value Example or Default                       |
-|-----------|------------------------------------------|------------------------------------------------|
-| **yes**   | SyncTimeOffs.personioToken               | `CLIENT_ID&#124;CLIENT_SECRET`                      |
-| **yes**   | SyncTimeOffs.serviceAccountCredentials   | `{SERVICE_ACCOUNT_CREDENTIALS_FILE_CONTENT...}`|
-| no        | SyncTimeOffs.allowedDomains              | `giantswarm.io,giantswarm.com`                 |
-| no        | SyncTimeOffs.emailWhiteList              | `jonas@giantswarm.io,marcel@giantswarm.io`     |
-| no        | SyncTimeOffs.lookaheadDays               | `180`                                          |
-| no        | SyncTimeOffs.lookbackDays                | `30`                                           |
-| no        | SyncTimeOffs.maxSyncFailCount            | `10`                                           |
+| Mandatory | Property Key                             | Value Example or Default                        |
+|-----------|------------------------------------------|-------------------------------------------------|
+| **yes**   | SyncTimeOffs.personioToken               | `CLIENT_ID&#124;CLIENT_SECRET`                  |
+| **yes**   | SyncTimeOffs.serviceAccountCredentials   | `{SERVICE_ACCOUNT_CREDENTIALS_FILE_CONTENT...}` |
+| no        | SyncTimeOffs.allowedDomains              | `giantswarm.io,giantswarm.com`                  |
+| no        | SyncTimeOffs.emailWhiteList              | `jonas@giantswarm.io,marcel@giantswarm.io`      |
+| no        | SyncTimeOffs.skipApprovalBlackList       | `parental`                                      |
+| no        | SyncTimeOffs.lookaheadDays               | `180`                                           |
+| no        | SyncTimeOffs.lookbackDays                | `30`                                            |
+| no        | SyncTimeOffs.maxSyncFailCount            | `10`                                            |
 


### PR DESCRIPTION
## Reasoning

All approval shall be skipped by default for all TimeOffTypes, except some whose names (ie. keywords) are listed on a black-list.

## Implementation

Implementation and testing was a bit harder than expected, because the `POST /company/time-offs` `skip_approval` parameter doesn't seem to accept boolean values (`true`, `false`, `1` or `0`) as documented here:
https://developer.personio.de/reference/post_company-time-offs

Instead just not listing the parameter `skip_approval` at all in the request body seems to do the trick. 🤔

In any case we should keep an eye on this during further tests, since the weird "approval workflows" can cause unwanted emails to be sent for each synchronized event.