### PR TITLE
Restore event.updated Timestamp clobbered by syncFailCount Update

### DIFF
--- a/sync-timeoffs/SyncTimeOffs.js
+++ b/sync-timeoffs/SyncTimeOffs.js
@@ -563,7 +563,7 @@ function syncActionUpdateEventFailCount_(calendar, primaryEmail, event, failCoun
         setEventPrivateProperty_(event, 'syncFailCount', failCount);
 
         // set syncFailUpdated to allow restoring the original "updated" timestamp, via getOriginalEventUpdated_()
-        const deadZoneEndMillies = Date.now() + (30 * 1000);  // now + 30s (calendar.update() won't need more than 30s)
+        const deadZoneEndMillies = Date.now() + (30 * 1000);  // assuming calendar.update() won't need more than 30s
         setEventPrivateProperty_(event, 'syncFailUpdated', `${deadZoneEndMillies}|${updatedAt.valueOf()}`);
 
         calendar.update('primary', event.id, event);


### PR DESCRIPTION
## Problem

Updating `syncFailCount` causes `event.updated` to be overwritten. Unfortunately we need the original `event.updated` to make a decision about the sync direction (which event is more up-to-date).

## Implementation

* Save the `event.updated` timestamp and the time of the synthetic update changing it (window)
* Use the saved `updated` value if `event.updated` lies within the synthetic update window.

Fixes giantswarm/giantswarm#25953
