### PR TITLE
Add Braces as Keyword Boundary Characters

### DIFF
--- a/sync-timeoffs/SyncTimeOffs.js
+++ b/sync-timeoffs/SyncTimeOffs.js
@@ -289,7 +289,7 @@ class TimeOffTypeConfig {
         const pattern = [];
         for (let timeOffType of timeOffTypes) {
             const keyword = TimeOffTypeConfig.extractKeyword(timeOffType.attributes.name);
-            pattern.push(new RegExp(`(^|[\\s:-])(${keyword})([\\s:-]|$)`, "sim"));
+            pattern.push(new RegExp(`(^|[\\s:-[(])(${keyword})([\\s:-\\])]|$)`, "sim"));
         }
         this.pattern = pattern;
         this.skipApprovalBlackList = skipApprovalBlackList || [];


### PR DESCRIPTION
## Reasoning

Users complained about keywords not being accepted in event summaries like `[no-oncall] I need space`.

Slack message: https://gigantic.slack.com/archives/C03LV8E0RL7/p1677060272840369?thread_ts=1676979742.913849&cid=C03LV8E0RL7

## Solution

Add `[]()` as additional keyword boundary characters.