### PR TITLE
Implement white-listing whole teams

### DIFF
--- a/sync-timeoffs/SyncTimeOffs.js
+++ b/sync-timeoffs/SyncTimeOffs.js
@@ -198,6 +198,8 @@ function setProperties(properties, deleteAllOthers) {
  * Will only do something if the white-list is not empty (already enabled).
  *
  * @param {string|Array<string>} Team name or array of team names that should be white-listed
+ *
+ * @return {string} Returns the updated white-list.
  */
 function whiteListTeam(teams) {
     if (!teams) {
@@ -224,7 +226,10 @@ function whiteListTeam(teams) {
         }
     }
 
-    TriggerUtil.setProperties({[EMAIL_WHITELIST_KEY]: whiteList.join(',')}, false);
+    const whiteListStr = whiteList.join(',');
+    TriggerUtil.setProperties({[EMAIL_WHITELIST_KEY]: whiteListStr}, false);
+
+    return whiteListStr;
 }
 
 


### PR DESCRIPTION
Towards giantswarm/giantswarm#24049

## Description

Adds a script function `whiteListTeam(teams)` that adds all members of the specified teams to the comma-separated list in ScriptProperty `SyncTimeOffs.emailWhiteList`.

The function returns the updated white-list.

The function only has an effect if the white-list is not empty, which is a safety feature to prevent accidental DoS when finally in production (white-list empty).

This supports staggered roll-out of the synchronization feature to allow enough time to check logs and notice errors/complaints early.

Code is already deployed and in use.