### PR TITLE
Reduce Max Runtime to 4:50min

### DIFF
--- a/sync-timeoffs/SyncTimeOffs.js
+++ b/sync-timeoffs/SyncTimeOffs.js
@@ -142,8 +142,11 @@ function syncTimeOffs() {
     const lookaheadMillies = Math.round(getLookaheadDays_() * 24 * 60 * 60 * 1000);
     // how many Personio action retries per event?
     const maxFailCount = getMaxSyncFailCount_();
+
     // after how many milliseconds should this script stop by itself (to avoid forced termination/unclean state)?
-    const maxRuntimeMillies = Math.round(320 * 1000); // 5:20 minutes (hard AppsScript kill comes at 6:00 minutes)
+    // 4:50 minutes (hard AppsScript kill comes at 6:00 minutes)
+    // stay under 5 min. to ensure termination before the next instances starts if operating at 5 min. job delay
+    const maxRuntimeMillies = Math.round(290 * 1000);
 
     const fetchTimeMin = Util.addDateMillies(new Date(epoch), lookbackMillies);
     fetchTimeMin.setUTCHours(0, 0, 0, 0); // round down to start of day


### PR DESCRIPTION
## Summary

Reduce the maximum runtime from 5:20min to 4:50min.

Since the voluntary termination logic has proven robust, this serves to avoid generating lots of failed task invocations that clutter the logs and may lead to confusing "something failed" emails being sent out:
![grafik](https://user-images.githubusercontent.com/18163495/222497421-bc03e6f8-2f01-4377-870b-206c52295170.png)

*Background:*

This wouldn't be necessary if we could configure a 6 or 7 minute job frequency. However the Apps Script scheduler allows only `1,5,10,30 minutes`.

Making the script operate at a 1 min. frequency without "Failed" starts (rejected due to locking) is currently not possible, as the Personio API is extremely slow.