### PR TITLE
Update time-off/event on differing type

### DIFF
--- a/sync-timeoffs/SyncTimeOffs.js
+++ b/sync-timeoffs/SyncTimeOffs.js
@@ -471,7 +471,8 @@ function syncTimeOffs_(personio, calendar, employee, epoch, timeOffTypeConfig, f
                 } else {
                     // need to convert to be able to compare start/end timestamps (Personio is whole-day/half-day only)
                     const updatedTimeOff = convertOutOfOfficeToTimeOff_(timeOffTypeConfig, employee, event, timeOff);
-                    if (updatedTimeOff && (!updatedTimeOff.startAt.equals(timeOff.startAt) || !updatedTimeOff.endAt.equals(timeOff.endAt))) {
+                    if (updatedTimeOff
+                        && (!updatedTimeOff.startAt.equals(timeOff.startAt) || !updatedTimeOff.endAt.equals(timeOff.endAt) || updatedTimeOff.typeId !== timeOff.typeId)) {
                         // start/end timestamps differ, now check which (Personio/Google Calendar) has more recent changes
                         if (+timeOff.updatedAt >= +eventUpdatedAt) {
                             syncActionUpdateEvent_(calendar, primaryEmail, event, timeOff);


### PR DESCRIPTION
## Reasoning

Currently we only trigger an updating sync if the start/end dates of an already synchronized event change.

That may not be enough. If a user changes relevant parts of a title we may also want to initiate synchronization to avoid forcing users to re-create events or change their time to force synchronization (workaround).

This was discovered by @puja108 in solving https://github.com/giantswarm/giantswarm/issues/25789#issuecomment-1456340014.

## Implementation

1. Compare updated time-off `typeId` field with the already synced time-off's `typeId` in addition to the `start` and `end` timestamps.
2. Sync if `typeId` fields are not equal (using the ID seems more safe than the name).
