### PR TITLE
Fix Release Workflow

### DIFF
--- a/.github/workflows/upload-release.yaml
+++ b/.github/workflows/upload-release.yaml
@@ -18,10 +18,10 @@ jobs:
       - name: Upload Files to Release
         env:
           GITHUB_TOKEN: "${{ secrets.TAYLORBOT_GITHUB_ACTION }}"
-          VERSION: ${{ github.event.release.name }}
-          COMMITISH: ${{ github.event.release.target_commitish }}
-          SENDER: ${{ github.event.sender }}
-          REPOSITORY: ${{ github.event.repository }}
+          VERSION: "${{ github.event.release.name }}"
+          COMMITISH: "${{ github.event.release.target_commitish }}"
+          SENDER: "${{ github.event.sender }}"
+          REPOSITORY: "${{ github.event.repository }}"
         run: |
           go install github.com/tcnksm/ghr@v0.16.0
           ghr -t ${GITHUB_TOKEN} -u ${SENDER} -r ${REPOSITORY} -c ${COMMITISH} -delete ${VERSION} ./lib-output/


### PR DESCRIPTION
## Summary

Release workflow fails with error `A mapping was not expected`.

Try to fix that.