### PR TITLE
fix: disable account specific CfP reminders

### DIFF
--- a/conference-form-to-calendar/ConferenceSync.js
+++ b/conference-form-to-calendar/ConferenceSync.js
@@ -99,8 +99,8 @@ function syncToCalendar_(spreadsheetId, sheetName, calendarId) {
 
         event.setDescription(description);
 
-        // Reminder 7 days before
-        event.addEmailReminder(10080)
+        // Reminder 7 days before (this only works for the current users reminders array and stacks)
+        // event.addEmailReminder(10080)
 
         const eventId = Utilities.base64Encode(event.getId().split('@')[0] + calendarId).replace('=', '');
         const url = `https://calendar.google.com/calendar/event?eid=${eventId}`;


### PR DESCRIPTION
## Summary

As discovered in a [Slack thread](https://gigantic.slack.com/archives/CEYSRD926/p1682316992047249) the `Event.addEmailReminders()` API:
 * creates user specific reminders
 * stacks reminders (many emails sent out if API is called multiple times)

Since there is no (easy, without impersonating and iterating over all org users) way to obtain the list of users subscribed to a calendar, we decided not to implement proper support of the feature at this time.