### PR TITLE
fix: improve fetch() compatibility, async/await stripping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ gas_projects_clean = $(subst /.clasp.json,-clean,$(clasp_files))
 #
 lib_header_file =
 lib_trailer_file =
-lib_filter = 's/([[(),.;= \t\n])(async|await)([() \t\n])/\1\3/g'
+lib_filter = 's/([[()\!\&\|,.;= +\-\*\t\t\n])(async|await)([() \t\n])/\1\3/g'
 lib_files = lib/OAuth2.gs lib/UrlFetchJsonClient.js lib/CalendarListClient.js \
     lib/CalendarClient.js lib/PersonioAuthV1.js lib/PersonioClientV1.js lib/GmailClientV1.js lib/SheetUtil.js \
     lib/TriggerUtil.js lib/Util.js lib/PeopleTime.js

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ gas_projects_clean = $(subst /.clasp.json,-clean,$(clasp_files))
 #
 lib_header_file =
 lib_trailer_file =
-lib_filter = 's/([[()\!\&\|,.;= +\-\*\t\t\n])(async|await)([() \t\n])/\1\3/g'
+lib_filter = 's/([[()\?\!\&\|,.;= +\-\*\t\t\n])(async|await)([() \t\n])/\1\3/g'
 lib_files = lib/OAuth2.gs lib/UrlFetchJsonClient.js lib/CalendarListClient.js \
     lib/CalendarClient.js lib/PersonioAuthV1.js lib/PersonioClientV1.js lib/GmailClientV1.js lib/SheetUtil.js \
     lib/TriggerUtil.js lib/Util.js lib/PeopleTime.js

--- a/lib/Header.js
+++ b/lib/Header.js
@@ -12,6 +12,15 @@ module = {exports: {}};
 class UrlFetchApp {
     static async fetch(url, options) {
         try {
+            // fixup some API differences (thanks Google)
+            if (options.contentType) {
+                options.headers = {...options.headers, ['Content-Type']: options.contentType};
+            }
+            if (options.payload) {
+                options.body = options.payload;
+                options.payload = undefined;
+            }
+
             const r = await fetch(url, options);
             const text = await r.text();
             r.getResponseCode = () => r.status;


### PR DESCRIPTION
## Summary

Two defects were noticed during development/testing of giantswarm/giantswarm#26549:

 * `await` keyword wasn't stripped from `lib.js` in all situations (certain operators missing)
   * lead to an upload failure
   * Google Apps Scripts checks syntax on upload, so these issues become immediately visible
 * UrlFetchApp.fetch() to fetch() wrapper lacked some special processing for incompatible parts of the APIs:
   * `options.body` VS `options.payload`
   * `options.contentType` VS `options.headers['Content-Type']`