### PR TITLE
feat: Add Selective Unsync Helper

### DIFF
--- a/sync-timeoffs/SyncTimeOffs.js
+++ b/sync-timeoffs/SyncTimeOffs.js
@@ -198,6 +198,8 @@ async function syncTimeOffs() {
 
 /** Utility function to unsynchronize certain events and delete the associated absence from Personio.
  *
+ * @note This is a destructive operation, USE WITH UTMOST CARE!
+ *
  * @param title The event title (only events whose title includes this string are de-synced).
  */
 async function unsyncTimeOffs_(title) {

--- a/sync-timeoffs/SyncTimeOffs.js
+++ b/sync-timeoffs/SyncTimeOffs.js
@@ -246,11 +246,6 @@ async function unsyncTimeOffs_(title) {
     );
     Util.shuffleArray(employees);
 
-    // if bulk requests are preferred, prefetch all Personio time-offs
-    const allTimeOffs = isPreferBulkRequestsEnabled_()
-        ? await queryPersonioTimeOffs_(personio, fetchTimeMin, fetchTimeMax, undefined)
-        : undefined;
-
     Logger.log('Unsyncing events with title containing "%s" between %s and %s for %s accounts', title, fetchTimeMin.toISOString(), fetchTimeMax.toISOString(), '' + employees.length);
 
     let firstError = null;

--- a/sync-timeoffs/SyncTimeOffs.js
+++ b/sync-timeoffs/SyncTimeOffs.js
@@ -196,6 +196,120 @@ async function syncTimeOffs() {
 }
 
 
+/** Utility function to unsynchronize certain events and delete the associated absence from Personio.
+ *
+ * @param title The event title (only events whose title includes this string are de-synced).
+ */
+async function unsyncTimeOffs_(title) {
+
+    const scriptLock = LockService.getScriptLock();
+    if (!scriptLock.tryLock(5000)) {
+        throw new Error('Failed to acquire lock. Only one instance of this script can run at any given time!');
+    }
+
+    const allowedDomains = (getScriptProperties_().getProperty(ALLOWED_DOMAINS_KEY) || '')
+        .split(',')
+        .map(d => d.trim());
+
+    const emailWhiteList = getEmailWhiteList_();
+    const isEmailAllowed = email => (!emailWhiteList.length || emailWhiteList.includes(email))
+        && allowedDomains.includes(email.substring(email.lastIndexOf('@') + 1));
+
+    Logger.log('Configured to handle accounts %s on domains %s', emailWhiteList.length ? emailWhiteList : '', allowedDomains);
+
+    // all timing related activities are relative to this EPOCH
+    const epoch = new Date();
+
+    // how far back to sync events/time-offs
+    const lookbackMillies = -Math.round(getLookbackDays_() * 24 * 60 * 60 * 1000);
+    // how far into the future to sync events/time-offs
+    const lookaheadMillies = Math.round(getLookaheadDays_() * 24 * 60 * 60 * 1000);
+
+    // after how many milliseconds should this script stop by itself (to avoid forced termination/unclean state)?
+    // 4:50 minutes (hard AppsScript kill comes at 6:00 minutes)
+    // stay under 5 min. to ensure termination before the next instances starts if operating at 5 min. job delay
+    const maxRuntimeMillies = Math.round(290 * 1000);
+
+    const fetchTimeMin = Util.addDateMillies(new Date(epoch), lookbackMillies);
+    fetchTimeMin.setUTCHours(0, 0, 0, 0); // round down to start of day
+    const fetchTimeMax = Util.addDateMillies(new Date(epoch), lookaheadMillies);
+    fetchTimeMax.setUTCHours(24, 0, 0, 0); // round up to end of day
+
+    const personioCreds = getPersonioCreds_();
+    const personio = PersonioClientV1.withApiCredentials(personioCreds.clientId, personioCreds.clientSecret);
+
+    // load and prepare list of employees to process
+    const employees = await personio.getPersonioJson('/company/employees').filter(employee =>
+        employee.attributes.status.value !== 'inactive' && isEmailAllowed(employee.attributes.email.value)
+    );
+    Util.shuffleArray(employees);
+
+    // if bulk requests are preferred, prefetch all Personio time-offs
+    const allTimeOffs = isPreferBulkRequestsEnabled_()
+        ? await queryPersonioTimeOffs_(personio, fetchTimeMin, fetchTimeMax, undefined)
+        : undefined;
+
+    Logger.log('Unsyncing events with title containing "%s" between %s and %s for %s accounts', title, fetchTimeMin.toISOString(), fetchTimeMax.toISOString(), '' + employees.length);
+
+    let firstError = null;
+    let processedCount = 0;
+    for (const employee of employees) {
+
+        const email = employee.attributes.email.value;
+
+        // we keep operating if handling calendar of a single user fails
+        try {
+            const calendar = await CalendarClient.withImpersonatingService(getServiceAccountCredentials_(), email);
+
+            // test against dead-line first
+            const deadlineTs = +epoch + maxRuntimeMillies;
+            let now = Date.now();
+            if (now >= deadlineTs) {
+                return false;
+            }
+
+            const allEvents = await queryCalendarEvents_(calendar, 'primary', fetchTimeMin, fetchTimeMax);
+            Util.shuffleArray(allEvents);
+
+            let failCount = 0;
+            const processedTimeOffIds = {};
+            for (const event of allEvents) {
+                if (now >= deadlineTs) {
+                    break;
+                }
+
+                const timeOffId = +event.extendedProperties?.private?.timeOffId;
+                if (timeOffId && (event.summary || '').includes(title)) {
+                    try {
+                        await deletePersonioTimeOff_({id: timeOffId});
+                    } catch (e) {
+                        Logger.log('Failed to remove time-off for de-synced event of user %s: %s', email, e);
+                    }
+
+                    setEventPrivateProperty_(event, 'timeOffId', null);
+
+                    await calendar.update('primary', event.id, event);
+                    Logger.log('De-synced event "%s" at %s for user %s', event.summary, event.start.dateTime || event.start.date, email);
+                }
+            }
+        } catch (e) {
+            Logger.log('Failed to unsync matching time-offs/out-of-offices of user %s: %s', email, e);
+            firstError = firstError || e;
+        }
+        ++processedCount;
+    }
+
+    Logger.log('Completed de-synchronization for %s of %s accounts', '' + processedCount, '' + employees.length);
+
+    // for completeness, also automatically released at exit
+    scriptLock.releaseLock();
+
+    if (firstError) {
+        throw firstError;
+    }
+}
+
+
 /** Uninstall triggers. */
 function uninstall() {
     TriggerUtil.uninstall(TRIGGER_HANDLER_FUNCTION);


### PR DESCRIPTION
Resolves giantswarm/giantswarm#26991

## Summary

To ease admin cleanup tasks, provide a private `unsyncTimeOffs_()` function.

See https://github.com/giantswarm/giantswarm/issues/26991 for details.

## Reasons for Creating a Helper Function

1. Setting the private properties from the Gcal UI isn't possible, so one could only delete and re-create events.
2. To safely un-sync without risking event deletion/re-creation during a later sync run, the script lock must be taken (!)
3. Handling many events for multiple employee accounts is very time-consuming