### PR TITLE
fix: log timeOff.comment on inserts

### DIFF
--- a/sync-timeoffs/SyncTimeOffs.js
+++ b/sync-timeoffs/SyncTimeOffs.js
@@ -762,7 +762,7 @@ async function syncActionInsertTimeOff_(personio, calendar, primaryEmail, event,
         setEventPrivateProperty_(event, 'timeOffId', createdTimeOff.id);
         updateEventPersonioDeepLink_(event, createdTimeOff);
         await calendar.update('primary', event.id, event);
-        Logger.log('Inserted TimeOff "%s" at %s for user %s', createdTimeOff.typeName, String(createdTimeOff.startAt), primaryEmail);
+        Logger.log('Inserted TimeOff "%s" at %s for user %s: %s', createdTimeOff.typeName, String(createdTimeOff.startAt), primaryEmail, createdTimeOff.comment);
         return true;
     } catch (e) {
         Logger.log('Failed to insert new TimeOff "%s" at %s for user %s: %s', event.summary, event.start.dateTime || event.start.date, primaryEmail, e);


### PR DESCRIPTION
## Summary

@ubergesundheit noticed that an unexpected event on his calendar got synced: 

The reason for the event being included in the sync could not be determined.

The type of object is determined on the initial insert into Personio, thus the event title should be logged at this point in time.