### PR TITLE
feat: implement successful sync icon

### DIFF
--- a/sync-timeoffs/SyncTimeOffs.js
+++ b/sync-timeoffs/SyncTimeOffs.js
@@ -715,7 +715,7 @@ async function syncActionUpdateTimeOff_(personio, calendar, primaryEmail, event,
         const createdTimeOff = await createPersonioTimeOff_(personio, updatedTimeOff);
         setEventPrivateProperty_(event, 'timeOffId', createdTimeOff.id);
         updateEventPersonioDeepLink_(event, createdTimeOff);
-        if (!event.summary.includes('⇵')) {
+        if (!/ ?⇵$/.test(event.summary)) {
             event.summary += ' ⇵';
         }
         await calendar.update('primary', event.id, event);
@@ -762,7 +762,7 @@ async function syncActionInsertTimeOff_(personio, calendar, primaryEmail, event,
         const createdTimeOff = await createPersonioTimeOff_(personio, newTimeOff);
         setEventPrivateProperty_(event, 'timeOffId', createdTimeOff.id);
         updateEventPersonioDeepLink_(event, createdTimeOff);
-        if (!event.summary.includes('⇵')) {
+        if (!/ ?⇵$/.test(event.summary)) {
             event.summary += ' ⇵';
         }
         await calendar.update('primary', event.id, event);
@@ -917,7 +917,7 @@ function convertOutOfOfficeToTimeOff_(timeOffTypeConfig, employee, event, existi
         endAt: endAt,
         typeId: timeOffType.attributes.id,
         typeName: timeOffType.attributes.name,
-        comment: event.summary.replace(' ⇵', ''),
+        comment: event.summary.replace(/ ?⇵$/, ''),
         updatedAt: new Date(event.updated),
         employeeId: employee.attributes.id.value,
         email: employee.attributes.email.value,

--- a/sync-timeoffs/SyncTimeOffs.js
+++ b/sync-timeoffs/SyncTimeOffs.js
@@ -715,6 +715,9 @@ async function syncActionUpdateTimeOff_(personio, calendar, primaryEmail, event,
         const createdTimeOff = await createPersonioTimeOff_(personio, updatedTimeOff);
         setEventPrivateProperty_(event, 'timeOffId', createdTimeOff.id);
         updateEventPersonioDeepLink_(event, createdTimeOff);
+        if (!event.summary.includes('⇵')) {
+            event.summary += ' ⇵';
+        }
         await calendar.update('primary', event.id, event);
         Logger.log('Updated TimeOff "%s" at %s for user %s', createdTimeOff.typeName, String(createdTimeOff.startAt), primaryEmail);
         return true;
@@ -759,6 +762,9 @@ async function syncActionInsertTimeOff_(personio, calendar, primaryEmail, event,
         const createdTimeOff = await createPersonioTimeOff_(personio, newTimeOff);
         setEventPrivateProperty_(event, 'timeOffId', createdTimeOff.id);
         updateEventPersonioDeepLink_(event, createdTimeOff);
+        if (!event.summary.includes('⇵')) {
+            event.summary += ' ⇵';
+        }
         await calendar.update('primary', event.id, event);
         Logger.log('Inserted TimeOff "%s" at %s for user %s: %s', createdTimeOff.typeName, String(createdTimeOff.startAt), primaryEmail, createdTimeOff.comment);
         return true;
@@ -911,7 +917,7 @@ function convertOutOfOfficeToTimeOff_(timeOffTypeConfig, employee, event, existi
         endAt: endAt,
         typeId: timeOffType.attributes.id,
         typeName: timeOffType.attributes.name,
-        comment: event.summary.replace(' [synced]', ''),
+        comment: event.summary.replace(' ⇵', ''),
         updatedAt: new Date(event.updated),
         employeeId: employee.attributes.id.value,
         email: employee.attributes.email.value,
@@ -980,7 +986,7 @@ function createEventFromTimeOff_(timeOffTypeConfig, timeOff) {
                 timeOffId: timeOff.id
             }
         },
-        summary: `${timeOff.comment} [synced]`
+        summary: `${timeOff.comment} ⇵`
     };
 
     // if we can't guess the corresponding time-off-type, prefix the event summary with its name


### PR DESCRIPTION
Resolves giantswarm/giantswarm#26565

## Summary

Adds a sync icon (⇵) to all Gcal event titles successfully synchronized with Personio.

The icon is not shown on Personio TimeOff descriptions.