### PR TITLE
feat: filter event created by other users

### DIFF
--- a/sync-timeoffs/SyncTimeOffs.js
+++ b/sync-timeoffs/SyncTimeOffs.js
@@ -880,6 +880,11 @@ async function queryPersonioTimeOffs_(personio, timeMin, timeMax, employeeId) {
 /** Construct a matching TimeOff structure for a Google Calendar event. */
 function convertOutOfOfficeToTimeOff_(timeOffTypeConfig, employee, event, existingTimeOff) {
 
+    // skip events created by other users
+    if (event?.creator?.email && event?.creator?.email !== employee.attributes.email.value) {
+        return undefined;
+    }
+
     let timeOffType = timeOffTypeConfig.findByKeywordMatch(event.summary || '');
     if (!timeOffType && existingTimeOff) {
         const previousType = timeOffTypeConfig.findById(existingTimeOff.typeId);


### PR DESCRIPTION
Resolves giantswarm/giantswarm#26776

## Summary

Don't return TimeOffs for events created by other users than the owner of the personal calendar.

That means that such events won't be synced with Personio.

This should effectively fulfill the user-case described in giantswarm/giantswarm#26776, even though it is not exactly the implementation initially described.