### PR TITLE
fix: add missing dash escape

### DIFF
--- a/sync-timeoffs/SyncTimeOffs.js
+++ b/sync-timeoffs/SyncTimeOffs.js
@@ -467,7 +467,7 @@ class TimeOffTypeConfig {
         const pattern = [];
         for (let timeOffType of timeOffTypes) {
             const keyword = TimeOffTypeConfig.extractKeyword(timeOffType.attributes.name);
-            pattern.push(new RegExp(`(^|[\\s:-[(])(${keyword})([\\s:-\\])]|$)`, "sim"));
+            pattern.push(new RegExp(`(^|[\\s:\\-[(])(${keyword})([\\s:\\-\\])]|$)`, "sim"));
         }
         this.pattern = pattern;
         this.skipApprovalBlackList = skipApprovalBlackList || [];


### PR DESCRIPTION
Resolves giantswarm/giantswarm#27364

## Summary

Incorrect matching expressions for Time-Off-Type keywords could lead to unwanted events being synced.

This PR corrects this by fixing escaping of the `-` character in the expression.