### PR TITLE
feat: implement calendar unsubscription helper

### DIFF
--- a/lib/CalendarListClient.js
+++ b/lib/CalendarListClient.js
@@ -25,6 +25,13 @@ class CalendarListClient extends UrlFetchJsonClient {
     }
 
 
+    async delete(calendarId) {
+        return await this.fetchJson(`https://www.googleapis.com/calendar/v3/users/me/calendarList/${calendarId}`, {
+            method: 'delete'
+        });
+    }
+
+
     async list() {
         const calendars = [];
         const params = {

--- a/setup-newjoiners/appsscript.json
+++ b/setup-newjoiners/appsscript.json
@@ -27,6 +27,6 @@
   "exceptionLogging": "STACKDRIVER",
   "runtimeVersion": "V8",
   "executionApi": {
-    "access": "DOMAIN"
+    "access": "MYSELF"
   }
 }


### PR DESCRIPTION
Towards giantswarm/giantswarm#26592

## Summary

Implement the necessary helper function to unsubscribe all active employees from certain calendars.

### Execution API Manifest Change

The execution privilege setting in the manifest has been changed from `DOMAIN` to `MYSELF` to prevent other domain accounts than ${the automation account} from unsubscribing other's calendars.