### PR TITLE
fix: missing await

### DIFF
--- a/sync-timeoffs/SyncTimeOffs.js
+++ b/sync-timeoffs/SyncTimeOffs.js
@@ -175,7 +175,8 @@ async function syncTimeOffs() {
         // we keep operating if handling calendar of a single user fails
         try {
             const calendar = await CalendarClient.withImpersonatingService(getServiceAccountCredentials_(), email);
-            if (!syncTimeOffs_(personio, calendar, employee, epoch, timeOffTypeConfig, fetchTimeMin, fetchTimeMax, maxFailCount, maxRuntimeMillies, allTimeOffs)) {
+            const isCompleted = await syncTimeOffs_(personio, calendar, employee, epoch, timeOffTypeConfig, fetchTimeMin, fetchTimeMax, maxFailCount, maxRuntimeMillies, allTimeOffs);
+            if (!isCompleted) {
                 break;
             }
         } catch (e) {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/27691

## Summary

Add an `await` in call to `syncTimeOffs_()` to avoid receiving callbacks after script main function completion (observed in logs).