### PR TITLE
fix: make half-day selection more precise

### DIFF
--- a/sync-timeoffs/SyncTimeOffs.js
+++ b/sync-timeoffs/SyncTimeOffs.js
@@ -913,8 +913,8 @@ function convertOutOfOfficeToTimeOff_(timeOffTypeConfig, employee, event, existi
     const localTzOffsetEnd = event.end.date ? Util.getNamedTimeZoneOffset(event.end.timeZone, new Date(event.end.date)) : undefined;
     const startAt = PeopleTime.fromISO8601(event.start.dateTime || event.start.date, undefined, localTzOffsetStart)
         .normalizeHalfDay(false, halfDaysAllowed);
-    const endAt = PeopleTime.fromISO8601(event.end.dateTime || event.end.date, undefined, localTzOffsetEnd)
-        .normalizeHalfDay(true, halfDaysAllowed);
+    const endAtRaw = PeopleTime.fromISO8601(event.end.dateTime || event.end.date, undefined, localTzOffsetEnd);
+    const endAt = endAtRaw.normalizeHalfDay(true, halfDaysAllowed && (!startAt.isHalfDay() || !startAt.isAtSameDay(endAtRaw)));
 
     const skipApproval = timeOffTypeConfig.isSkippingApprovalAllowed(timeOffType.attributes.id);
 

--- a/sync-timeoffs/SyncTimeOffs.js
+++ b/sync-timeoffs/SyncTimeOffs.js
@@ -943,8 +943,8 @@ async function deletePersonioTimeOff_(personio, timeOff) {
 /** Generate payload for a personio time-off request. */
 function generatePersonioTimeOffPayload_(timeOff) {
     const isMultiDay = !timeOff.startAt.isAtSameDay(timeOff.endAt);
-    const halfDayStart = isMultiDay ? timeOff.startAt.isHalfDay() : timeOff.endAt.isHalfDay() && timeOff.startAt.isFirstHalfDay();
-    const halfDayEnd = isMultiDay ? timeOff.endAt.isHalfDay() : timeOff.startAt.isHalfDay() && !timeOff.endAt.isFirstHalfDay();
+    const halfDayStart = (isMultiDay && timeOff.startAt.isHalfDay() && !timeOff.startAt.isFirstHalfDay()) || (timeOff.endAt.isHalfDay() && timeOff.endAt.isFirstHalfDay());
+    const halfDayEnd = (isMultiDay && timeOff.endAt.isHalfDay() && timeOff.endAt.isFirstHalfDay()) || (timeOff.startAt.isHalfDay() && !timeOff.startAt.isFirstHalfDay());
 
     const payload = {
         employee_id: timeOff.employeeId.toFixed(0),

--- a/sync-timeoffs/SyncTimeOffs.js
+++ b/sync-timeoffs/SyncTimeOffs.js
@@ -940,12 +940,11 @@ async function deletePersonioTimeOff_(personio, timeOff) {
 }
 
 
-/** Insert a new Personio TimeOff. */
-async function createPersonioTimeOff_(personio, timeOff) {
-
+/** Generate payload for a personio time-off request. */
+function generatePersonioTimeOffPayload_(timeOff) {
     const isMultiDay = !timeOff.startAt.isAtSameDay(timeOff.endAt);
-    const halfDayStart = isMultiDay ? timeOff.startAt.isHalfDay() : timeOff.endAt.isHalfDay();
-    const halfDayEnd = isMultiDay ? timeOff.endAt.isHalfDay() : timeOff.startAt.isHalfDay();
+    const halfDayStart = isMultiDay ? timeOff.startAt.isHalfDay() : timeOff.endAt.isHalfDay() && timeOff.startAt.isFirstHalfDay();
+    const halfDayEnd = isMultiDay ? timeOff.endAt.isHalfDay() : timeOff.startAt.isHalfDay() && !timeOff.endAt.isFirstHalfDay();
 
     const payload = {
         employee_id: timeOff.employeeId.toFixed(0),
@@ -962,6 +961,14 @@ async function createPersonioTimeOff_(personio, timeOff) {
         payload.skip_approval = "1";
     }
 
+    return payload;
+}
+
+
+/** Insert a new Personio TimeOff. */
+async function createPersonioTimeOff_(personio, timeOff) {
+
+    const payload = generatePersonioTimeOffPayload_(timeOff);
     const result = await personio.fetchJson('/company/time-offs', {
         method: 'post',
         payload: payload

--- a/tests/020-test-sync-timeoffs.mjs
+++ b/tests/020-test-sync-timeoffs.mjs
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import {generatePersonioTimeOffPayload_} from '../sync-timeoffs/SyncTimeOffs.js';
+
+const {PeopleTime} = (await import('../lib-output/lib.js')).default;
+
+// test generatePersonioTimeOffPayload_
+for (const [timeOffInput, expectedPayload] of [
+    [{startAt: PeopleTime.fromISO8601('2016-05-16T00:00:00+05:00'), endAt: PeopleTime.fromISO8601('2016-05-16T24:00:00+05:00')}, {half_day_start: "1", half_day_end: "1"}],
+    [{startAt: PeopleTime.fromISO8601('2016-05-16T00:00:00+05:00'), endAt: PeopleTime.fromISO8601('2016-05-17T24:00:00+05:00')}, {half_day_start: "0", half_day_end: "0"}],
+    [{startAt: PeopleTime.fromISO8601('2016-05-16T00:00:00+05:00'), endAt: PeopleTime.fromISO8601('2016-05-17T17:00:00+05:00')}, {half_day_start: "1", half_day_end: "1"}],
+    [{startAt: PeopleTime.fromISO8601('2016-05-16T01:00:00+05:00'), endAt: PeopleTime.fromISO8601('2016-05-17T11:00:00+05:00')}, {half_day_start: "1", half_day_end: "0"}],
+    [{startAt: PeopleTime.fromISO8601('2016-05-16T12:00:00+05:00'), endAt: PeopleTime.fromISO8601('2016-05-17T19:00:00+05:00')}, {half_day_start: "0", half_day_end: "1"}],
+    [{startAt: PeopleTime.fromISO8601('2016-05-16T12:00:00+05:00'), endAt: PeopleTime.fromISO8601('2016-05-17T12:15:00+05:00')}, {half_day_start: "0", half_day_end: "1"}],
+    [{startAt: PeopleTime.fromISO8601('2016-05-16T11:00:00+05:00'), endAt: PeopleTime.fromISO8601('2016-05-17T11:45:00+05:00')}, {half_day_start: "1", half_day_end: "0"}]
+]) {
+    const timeOff = {employeeId: 123, typeId: 456, ...timeOffInput};
+    const payload = generatePersonioTimeOffPayload_(timeOff);
+
+    for (const property of Object.keys(expectedPayload)) {
+        if (payload[property] !== expectedPayload[property]) {
+            assert.equal(payload[property], expectedPayload[property], `generatePersonioTimeOffPayload_() returned incorrect payload properties`);
+        }
+    }
+}

--- a/tests/020-test-sync-timeoffs.mjs
+++ b/tests/020-test-sync-timeoffs.mjs
@@ -1,24 +1,29 @@
 import assert from 'node:assert/strict';
-import {generatePersonioTimeOffPayload_} from '../sync-timeoffs/SyncTimeOffs.js';
-
+import fs from 'fs';
 const {PeopleTime} = (await import('../lib-output/lib.js')).default;
 
+/** Call some function in the code under test which doesn't export anything, without polluting our scope. */
+function createTestFunctionWrapper(fileName, functionName) {
+    return Function(`"use strict"; ${fs.readFileSync(fileName)}; return ${functionName}(...arguments);`);
+}
+
 // test generatePersonioTimeOffPayload_
+const generatePersonioTimeOffPayload_ = createTestFunctionWrapper('../sync-timeoffs/SyncTimeOffs.js', 'generatePersonioTimeOffPayload_');
 for (const [timeOffInput, expectedPayload] of [
-    [{startAt: PeopleTime.fromISO8601('2016-05-16T00:00:00+05:00'), endAt: PeopleTime.fromISO8601('2016-05-16T24:00:00+05:00')}, {half_day_start: "1", half_day_end: "1"}],
+    [{startAt: PeopleTime.fromISO8601('2016-05-16T00:00:00+05:00'), endAt: PeopleTime.fromISO8601('2016-05-16T24:00:00+05:00')}, {half_day_start: "0", half_day_end: "0"}],
     [{startAt: PeopleTime.fromISO8601('2016-05-16T00:00:00+05:00'), endAt: PeopleTime.fromISO8601('2016-05-17T24:00:00+05:00')}, {half_day_start: "0", half_day_end: "0"}],
-    [{startAt: PeopleTime.fromISO8601('2016-05-16T00:00:00+05:00'), endAt: PeopleTime.fromISO8601('2016-05-17T17:00:00+05:00')}, {half_day_start: "1", half_day_end: "1"}],
-    [{startAt: PeopleTime.fromISO8601('2016-05-16T01:00:00+05:00'), endAt: PeopleTime.fromISO8601('2016-05-17T11:00:00+05:00')}, {half_day_start: "1", half_day_end: "0"}],
-    [{startAt: PeopleTime.fromISO8601('2016-05-16T12:00:00+05:00'), endAt: PeopleTime.fromISO8601('2016-05-17T19:00:00+05:00')}, {half_day_start: "0", half_day_end: "1"}],
-    [{startAt: PeopleTime.fromISO8601('2016-05-16T12:00:00+05:00'), endAt: PeopleTime.fromISO8601('2016-05-17T12:15:00+05:00')}, {half_day_start: "0", half_day_end: "1"}],
-    [{startAt: PeopleTime.fromISO8601('2016-05-16T11:00:00+05:00'), endAt: PeopleTime.fromISO8601('2016-05-17T11:45:00+05:00')}, {half_day_start: "1", half_day_end: "0"}]
+    [{startAt: PeopleTime.fromISO8601('2016-05-16T00:00:00+05:00'), endAt: PeopleTime.fromISO8601('2016-05-17T17:00:00+05:00')}, {half_day_start: "0", half_day_end: "0"}],
+    [{startAt: PeopleTime.fromISO8601('2016-05-16T01:00:00+05:00'), endAt: PeopleTime.fromISO8601('2016-05-16T11:00:00+05:00')}, {half_day_start: "1", half_day_end: "0"}],
+    [{startAt: PeopleTime.fromISO8601('2016-05-16T12:00:00+05:00'), endAt: PeopleTime.fromISO8601('2016-05-16T19:00:00+05:00')}, {half_day_start: "0", half_day_end: "1"}],
+    [{startAt: PeopleTime.fromISO8601('2016-05-16T12:00:00+05:00'), endAt: PeopleTime.fromISO8601('2016-05-16T12:15:00+05:00')}, {half_day_start: "0", half_day_end: "1"}],
+    [{startAt: PeopleTime.fromISO8601('2016-05-16T11:00:00+05:00'), endAt: PeopleTime.fromISO8601('2016-05-16T11:45:00+05:00')}, {half_day_start: "1", half_day_end: "0"}]
 ]) {
     const timeOff = {employeeId: 123, typeId: 456, ...timeOffInput};
     const payload = generatePersonioTimeOffPayload_(timeOff);
 
     for (const property of Object.keys(expectedPayload)) {
         if (payload[property] !== expectedPayload[property]) {
-            assert.equal(payload[property], expectedPayload[property], `generatePersonioTimeOffPayload_() returned incorrect payload properties`);
+            assert.equal(payload[property], expectedPayload[property], `returned incorrect payload ${JSON.stringify(payload)} properties for timeOffInput ${JSON.stringify(timeOffInput)}`);
         }
     }
 }

--- a/tests/020-test-sync-timeoffs.mjs
+++ b/tests/020-test-sync-timeoffs.mjs
@@ -8,7 +8,7 @@ function createTestFunctionWrapper(fileName, functionName) {
 }
 
 // test generatePersonioTimeOffPayload_
-const generatePersonioTimeOffPayload_ = createTestFunctionWrapper('../sync-timeoffs/SyncTimeOffs.js', 'generatePersonioTimeOffPayload_');
+const generatePersonioTimeOffPayload_ = createTestFunctionWrapper('sync-timeoffs/SyncTimeOffs.js', 'generatePersonioTimeOffPayload_');
 for (const [timeOffInput, expectedPayload] of [
     [{startAt: PeopleTime.fromISO8601('2016-05-16T00:00:00+05:00'), endAt: PeopleTime.fromISO8601('2016-05-16T24:00:00+05:00')}, {half_day_start: "0", half_day_end: "0"}],
     [{startAt: PeopleTime.fromISO8601('2016-05-16T00:00:00+05:00'), endAt: PeopleTime.fromISO8601('2016-05-17T24:00:00+05:00')}, {half_day_start: "0", half_day_end: "0"}],


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/27691

## Summary

Single-day events which both start and end in the hour 12 (12:00 - 12:59) were erroneously interpreted and inserted/updated as whole-day time-offs in Personio (both `half_day_start` and `half_day_end` flags set).

## Changes

This PR fixes the issue by improving:
1. Interpretation and normalization of Google Calendar events into internal TimeOffs objects (dates + half-days)
    - Fixes the original issue
2. Serialization of internal TimeOff objects to Personio API time-off update payload/body
    - Avoids similar issues to the original issue from occuring again (robustness)
3. Relevant tests.
