### PR TITLE
onChangeStickyRows(): don't log error for missing config

### DIFF
--- a/sticky-rows/StickyRows.js
+++ b/sticky-rows/StickyRows.js
@@ -107,7 +107,7 @@ function onChangeStickyRows(event) {
     const config = mergeConfig_(key, {});
     if (!config.dynamic_range || !config.sticky_range || !config.controlCell) {
         // STICKY_ROWS() also reports this error, we can't forward since we know no control cell here
-        throw new Error("Please call STICK_ROWS() with a valid dynamic_range and sticky_range in a formula on the sheet");
+        return;
     }
 
     try {


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/28680

## Summary

Don't spam error log for unconfigured sheets in `onChangeStickyRows()`, since the owner of the trigger may get that via email.
