### PR TITLE
feat: improve regexp safety and support keyword variations

### DIFF
--- a/sync-timeoffs/SyncTimeOffs.js
+++ b/sync-timeoffs/SyncTimeOffs.js
@@ -468,7 +468,12 @@ class TimeOffTypeConfig {
         const pattern = [];
         for (let timeOffType of timeOffTypes) {
             const keyword = TimeOffTypeConfig.extractKeyword(timeOffType.attributes.name);
-            pattern.push(new RegExp(`(^|[\\s:\\-[(])(${keyword})([\\s:\\-\\])]|$)`, "sim"));
+            if (keyword) {
+                const safeKeyword = keyword.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '[\\$& _]');
+                pattern.push(new RegExp(`(^|[\\s:\\-[(])(${safeKeyword})([\\s:\\-\\])]|$)`, "sim"));
+            } else {
+                pattern.push(new RegExp('a^'));
+            }
         }
         this.pattern = pattern;
         this.skipApprovalBlackList = skipApprovalBlackList || [];


### PR DESCRIPTION
Resolves https://github.com/giantswarm/giantswarm/issues/29499

The question was voiced by @MarcelMue and another time from @ubergesundheit.

### Summary

This PR implements the following two changes:

- Support keyword variations (like `no oncall: ...` as well as `no_oncall: ...`, for keyword `no-oncall`)
- Escape special symbols in the extracted keyword before RegExp pattern assembly (safety)
- Handle a special case (no keyword found) properly (RegExp that won't match anything)

### Test

Integrating the feature also fixed a possible error (special symbols weren't escaped in the keyword when forming the pattern).

Test:
```
17:47:59.327 pattern = new RegExp('no-oncall'.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '[\\$& _]'))
17:47:59.353 /no[\- _]oncall/

17:48:04.050 'no oncall'.match(pattern)
17:48:04.071 Array [ "no oncall" ]

17:48:07.805 'no_oncall'.match(pattern)
17:48:07.827 Array [ "no_oncall" ]

17:48:25.253 'no-oncall'.match(pattern)
17:48:25.274 Array [ "no-oncall" ]
```