### PR TITLE
Allow more foreign events

### DIFF
--- a/sync-timeoffs/SyncTimeOffs.js
+++ b/sync-timeoffs/SyncTimeOffs.js
@@ -907,7 +907,10 @@ async function queryPersonioTimeOffs_(personio, timeMin, timeMax, employeeId) {
 function convertOutOfOfficeToTimeOff_(timeOffTypeConfig, employee, event, existingTimeOff) {
 
     // skip events created by other users
-    if (event?.creator?.email && event?.creator?.email !== employee.attributes.email.value) {
+    const email = employee.attributes.email.value;
+    if (event.creator?.email !== email
+        && event.organizer?.email !== email
+        && (!event.attendees || !event.attendees.some(attendee => attendee.email === email && attendee.responseStatus && attendee.responseStatus !== "declined"))) {
         return undefined;
     }
 


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/29860

### Summary

Users noticed that events created by other users aren't synchronized with Personio, even if those signify absences.

This PR allows synchronization of events under the following conditions:
- `event.creator.email == primaryEmail`
- `event.organizer.email  == primaryEmail`
- `event.attendees[].email == primaryEmail && event.responseStatus != 'declined'`

Previously only ` event.creator.email == primaryEmail` was tested.