### PR TITLE
Adapt to Personio API changes

### DIFF
--- a/sync-timeoffs/SyncTimeOffs.js
+++ b/sync-timeoffs/SyncTimeOffs.js
@@ -968,7 +968,7 @@ function convertOutOfOfficeToTimeOff_(timeOffTypeConfig, employee, event, existi
         return undefined;
     }
 
-    const halfDaysAllowed = !!timeOffType.attributes?.half_day_requests_enabled;
+    const halfDaysAllowed = true; // field `half_day_requests_enabled` removed from absence-types from Sep. 16
     const localTzOffsetStart = event.start.date ? Util.getNamedTimeZoneOffset(event.start.timeZone, new Date(event.start.date)) : undefined;
     const localTzOffsetEnd = event.end.date ? Util.getNamedTimeZoneOffset(event.end.timeZone, new Date(event.end.date)) : undefined;
     const startAt = PeopleTime.fromISO8601(event.start.dateTime || event.start.date, undefined, localTzOffsetStart)


### PR DESCRIPTION
### Summary

Personio removed several fields from their TimeOffType response object:
```
    legacy_category
    half_day_requests_enabled
    certification_required
    certification_submission_timeframe
    substitute_option
```

This PR removes all use of these fields in the library.