### PR TITLE
meetings: limit Slack mentions to actual Meet attendees

### DIFF
--- a/Makefile.main.mk
+++ b/Makefile.main.mk
@@ -14,7 +14,7 @@ lib_header_file =
 lib_trailer_file =
 lib_filter = 's/([[()\?\!\&\|,.;= +\-\*\t\t\n])(async|await)([() \t\n])/\1\3/g'
 lib_files = lib/OAuth2.gs lib/UrlFetchJsonClient.js lib/GeminiRestClient.js lib/SlackWebClient.js lib/CalendarListClient.js \
-    lib/CalendarClient.js lib/PersonioAuthV1.js lib/PersonioClientV1.js lib/DriveClientV1.js lib/GmailClientV1.js lib/SheetUtil.js \
+    lib/CalendarClient.js lib/MeetClient.js lib/DirectoryClient.js lib/PersonioAuthV1.js lib/PersonioClientV1.js lib/DriveClientV1.js lib/GmailClientV1.js lib/SheetUtil.js \
     lib/TriggerUtil.js lib/Util.js lib/PeopleTime.js
 
 .PHONY: all

--- a/lib/DirectoryClient.js
+++ b/lib/DirectoryClient.js
@@ -1,0 +1,47 @@
+/** Google People API client for reading the domain directory.
+ *
+ * Requires service account credentials with domain-wide delegation.
+ * Scope 'directory.readonly' must be authorized in Workspace Admin Console.
+ */
+class DirectoryClient extends UrlFetchJsonClient {
+
+    constructor(service) {
+        super(service);
+    }
+
+
+    /** Helper to create an impersonating instance. */
+    static async withImpersonatingService(serviceAccountCredentials, primaryEmail) {
+        const service = await UrlFetchJsonClient.createImpersonatingService('DirectoryClient-' + primaryEmail,
+            serviceAccountCredentials,
+            primaryEmail,
+            'https://www.googleapis.com/auth/directory.readonly');
+
+        return new DirectoryClient(service);
+    }
+
+
+    /** List all domain directory people with their names and email addresses.
+     *
+     * @returns {Promise<Array>} Array of person objects with names and emailAddresses fields
+     */
+    async listDirectoryPeople() {
+        const people = [];
+        const queryParams = {
+            readMask: 'names,emailAddresses',
+            sources: 'DIRECTORY_SOURCE_TYPE_DOMAIN_PROFILE',
+            pageSize: 1000,
+            pageToken: undefined
+        };
+        do {
+            const query = DirectoryClient.buildQuery(queryParams);
+            const response = await this.getJson(`https://people.googleapis.com/v1/people:listDirectoryPeople${query}`);
+            if (response?.people) {
+                people.push(...response.people);
+            }
+            queryParams.pageToken = response?.nextPageToken;
+        } while (queryParams.pageToken);
+
+        return people;
+    }
+}

--- a/lib/MeetClient.js
+++ b/lib/MeetClient.js
@@ -1,0 +1,64 @@
+/** Google Meet REST API v2 client for reading conference records and participant data.
+ *
+ * Requires service account credentials with domain-wide delegation.
+ * Scope 'meetings.space.readonly' must be authorized in Workspace Admin Console.
+ */
+class MeetClient extends UrlFetchJsonClient {
+
+    constructor(service) {
+        super(service);
+    }
+
+
+    /** Helper to create an impersonating instance. */
+    static async withImpersonatingService(serviceAccountCredentials, primaryEmail) {
+        const service = await UrlFetchJsonClient.createImpersonatingService('MeetClient-' + primaryEmail,
+            serviceAccountCredentials,
+            primaryEmail,
+            'https://www.googleapis.com/auth/meetings.space.readonly');
+
+        return new MeetClient(service);
+    }
+
+
+    /** List conference records matching the given filter.
+     *
+     * @param filter EBNF filter string, e.g. 'space.meeting_code="abc-mnop-xyz"'
+     * @returns {Promise<Array>} Array of conference record objects
+     */
+    async listConferenceRecords(filter) {
+        const records = [];
+        const queryParams = { filter, pageToken: undefined };
+        do {
+            const query = MeetClient.buildQuery(queryParams);
+            const response = await this.getJson(`https://meet.googleapis.com/v2/conferenceRecords${query}`);
+            if (response?.conferenceRecords) {
+                records.push(...response.conferenceRecords);
+            }
+            queryParams.pageToken = response?.nextPageToken;
+        } while (queryParams.pageToken);
+
+        return records;
+    }
+
+
+    /** List participants of a conference record.
+     *
+     * @param conferenceRecordName The conference record resource name, e.g. 'conferenceRecords/abc123'
+     * @returns {Promise<Array>} Array of participant objects
+     */
+    async listParticipants(conferenceRecordName) {
+        const participants = [];
+        const queryParams = { pageSize: 250, pageToken: undefined };
+        do {
+            const query = MeetClient.buildQuery(queryParams);
+            const response = await this.getJson(`https://meet.googleapis.com/v2/${conferenceRecordName}/participants${query}`);
+            if (response?.participants) {
+                participants.push(...response.participants);
+            }
+            queryParams.pageToken = response?.nextPageToken;
+        } while (queryParams.pageToken);
+
+        return participants;
+    }
+}

--- a/lib/Trailer.js
+++ b/lib/Trailer.js
@@ -5,6 +5,8 @@ module.exports = {
     SlackWebClient: SlackWebClient,
     CalendarClient: CalendarClient,
     CalendarListClient: CalendarListClient,
+    MeetClient: MeetClient,
+    DirectoryClient: DirectoryClient,
     GmailClientV1: GmailClientV1,
     // OAuth2,  // exported directly via CommonJS module OAuth2.gs
     PeopleTime: PeopleTime,

--- a/meetings/Meetings.js
+++ b/meetings/Meetings.js
@@ -436,6 +436,7 @@ async function shareTeamMeetingArtifacts() {
     const listEventParams = {
         timeMin: fetchTimeMin.toISOString(),
         timeMax: fetchTimeMax.toISOString(),
+        conferenceDataVersion: 1,
     };
 
     // Fetch company glossary once for correcting terminology in summaries
@@ -638,9 +639,23 @@ async function summarizeAndPostToSlack_(event, geminiNotes, recording, drive, em
         const eventDate = new Date(event.start.dateTime || event.start.date);
         const formattedDate = Utilities.formatDate(eventDate, Session.getScriptTimeZone(), 'dd/MM/yy');
 
+        // Limit mentions to actual Meet attendees to avoid false name matches against unrelated employees
+        let meetAttendeeEmails = null;
+        try {
+            meetAttendeeEmails = await getMeetAttendeeEmails_(event);
+            if (meetAttendeeEmails) {
+                Logger.log(`Found ${meetAttendeeEmails.size} Meet attendees for ${event.summary}`);
+            }
+        } catch (e) {
+            Logger.log(`Failed to get Meet attendees for ${event.summary}, falling back to all employees: ${e}`);
+        }
+
+        const attendeeLabel = meetAttendeeEmails ? 'meeting attendees' : 'all employees';
         const nameToSlackMentionMapping = async () => {
-            // Use all active employees instead of event.attendees (which may be incomplete)
-            const employeeEmails = employees.map(emp => emp.attributes.email.value).filter(Boolean);
+            const relevantEmployees = meetAttendeeEmails
+                ? employees.filter(emp => meetAttendeeEmails.has(emp.attributes.email.value))
+                : employees;
+            const employeeEmails = relevantEmployees.map(emp => emp.attributes.email.value).filter(Boolean);
             if (employeeEmails.length === 0) {
                 return '';
             }
@@ -703,7 +718,7 @@ Guidelines:
 - Use clear, simple language
 - Only output the sections above, nothing else
 
-Name to Slack user ID lookup table (format "$DISPLAY_NAME -> $SLACK_MENTION") for all employees:
+Name to Slack user ID lookup table (format "$DISPLAY_NAME -> $SLACK_MENTION") for ${attendeeLabel}:
 <slack_mention_lookup_begin>
 ${await nameToSlackMentionMapping()}
 </slack_mention_lookup_end>
@@ -938,6 +953,102 @@ async function visitEvents_(visitor, listParams) {
     if (firstError) {
         throw firstError;
     }
+}
+
+
+/** Get emails of people who actually attended the Google Meet for a calendar event.
+ *
+ * Uses the Google Meet REST API to retrieve conference participants, then resolves
+ * their display names to primary emails via the Google Directory (People API).
+ * Both data sources use Google's identity system, so display names match reliably.
+ *
+ * Requires the following scopes to be authorized for the service account
+ * in Workspace Admin Console (domain-wide delegation):
+ * - meetings.space.readonly (Google Meet conference records)
+ * - directory.readonly (Google Directory people listing)
+ *
+ * @param event The calendar event (must include conferenceData, requires conferenceDataVersion=1 in list params)
+ * @returns {Promise<Set<string>|null>} Set of attendee email addresses, or null if attendance could not be determined
+ */
+async function getMeetAttendeeEmails_(event) {
+    const meetingCode = event.conferenceData?.conferenceId
+        || extractMeetingCode_(event);
+
+    if (!meetingCode) {
+        return null;
+    }
+
+    const email = event.creator?.email;
+    if (!email) {
+        return null;
+    }
+
+    const creds = getServiceAccountCredentials_();
+    const meet = await MeetClient.withImpersonatingService(creds, email);
+
+    // Search for conference records within a window around the event
+    const eventStart = new Date(event.start.dateTime || event.start.date);
+    const startFilter = new Date(eventStart.getTime() - 30 * 60 * 1000).toISOString();
+    const endFilter = new Date(eventStart.getTime() + 30 * 60 * 1000).toISOString();
+
+    const filter = `space.meeting_code="${meetingCode}" AND start_time>="${startFilter}" AND start_time<="${endFilter}"`;
+    const records = await meet.listConferenceRecords(filter);
+
+    if (!records.length) {
+        return null;
+    }
+
+    const participants = await meet.listParticipants(records[0].name);
+
+    // Resolve participant display names to emails via Google Directory
+    // (both Meet and Directory use Google identity, so names match)
+    const directoryNameToEmail = await getDirectoryNameToEmail_(creds, email);
+
+    const attendeeEmails = new Set();
+    for (const participant of participants) {
+        const displayName = (participant.signedinUser?.displayName || '').trim().toLowerCase();
+        if (displayName && directoryNameToEmail[displayName]) {
+            attendeeEmails.add(directoryNameToEmail[displayName]);
+        }
+    }
+
+    return attendeeEmails.size > 0 ? attendeeEmails : null;
+}
+
+
+/** Build a mapping from Google Directory display names (lowercase) to primary emails.
+ *
+ * @param serviceAccountCredentials Service account credentials JSON
+ * @param impersonateEmail Email of domain user to impersonate
+ * @returns {Promise<Object>} Map of lowercase display name to primary email
+ */
+async function getDirectoryNameToEmail_(serviceAccountCredentials, impersonateEmail) {
+    const directory = await DirectoryClient.withImpersonatingService(serviceAccountCredentials, impersonateEmail);
+    const people = await directory.listDirectoryPeople();
+
+    const nameToEmail = {};
+    for (const person of people) {
+        const name = person.names?.[0]?.displayName;
+        const email = person.emailAddresses?.[0]?.value;
+        if (name && email) {
+            nameToEmail[name.trim().toLowerCase()] = email;
+        }
+    }
+
+    return nameToEmail;
+}
+
+
+/** Extract Google Meet meeting code from calendar event entry points. */
+function extractMeetingCode_(event) {
+    const videoEntryPoint = event.conferenceData?.entryPoints?.find(ep => ep.entryPointType === 'video');
+    if (videoEntryPoint?.uri) {
+        const match = videoEntryPoint.uri.match(/meet\.google\.com\/([a-z]+-[a-z]+-[a-z]+)/);
+        if (match) {
+            return match[1];
+        }
+    }
+    return null;
 }
 
 


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/36413

### Summary

- Add `MeetClient` and `DirectoryClient` libraries for Google Meet REST API v2 and Google People API.
- Look up actual conference participants via Meet API instead of using all Personio employees for the Slack mention mapping.
- Resolve participant display names to primary emails via Google Directory (same identity system as Meet, avoids name spelling mismatches with Personio).
- Fall back to all employees if Meet API lookup fails (e.g. scope not yet authorized).

### Prerequisites

Authorize two new scopes for the service account in Workspace Admin Console (domain-wide delegation):
- `https://www.googleapis.com/auth/meetings.space.readonly`
- `https://www.googleapis.com/auth/directory.readonly`