### PR TITLE
chore(renovate): migrate to renovate-presets default.json5

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
-  "ignorePaths": ["**/.github/workflows/zz_**"]
-}

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>giantswarm/renovate-presets:default.json5"
+  ],
+  "ignorePaths": ["**/.github/workflows/zz_**"]
+}


### PR DESCRIPTION
Replaces `config:recommended` with `github>giantswarm/renovate-presets:default.json5`.

The old `renovate.json` is replaced by `renovate.json5`.

Kept:
- `ignorePaths: ["**/.github/workflows/zz_**"]` (repo-specific glob pattern, distinct from the standard preset exclusions)