### PR TITLE
fix: meeting summaries: switch Gemini model to gemini-3-pro-image

### DIFF
--- a/lib/GeminiRestClient.js
+++ b/lib/GeminiRestClient.js
@@ -12,7 +12,7 @@ class GeminiRestClient {
      * @return {Promise<string>} The summarized content
      */
     async summarizeText(docContent, prompt) {
-        const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-3-pro-preview:generateContent?key=${this._apiKey}`;
+        const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-3-pro-image:generateContent?key=${this._apiKey}`;
         
         const requestBody = {
             contents: [{


### PR DESCRIPTION
## What

`shareTeamMeetingArtifacts()` was using `gemini-3-pro-preview`, which Google has shut down. This broke meeting summary generation (the Gemini API now returns an error for that model).

## Change

Switch `GeminiRestClient` to `gemini-3-pro-image`.

The generated `meetings/lib.js` is rebuilt from `lib/GeminiRestClient.js` via the Makefile and is gitignored, so only the source file is changed here.